### PR TITLE
Change HashSet to LinkedHashSet for correctness concerning  SuperFloat tests

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/ParameterTypeContext.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/ParameterTypeContext.java
@@ -54,6 +54,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.javaruntype.type.ExtendsTypeParameter;
@@ -472,7 +473,7 @@ public class ParameterTypeContext {
         TypeParameter<?> p,
         AnnotatedType a) {
 
-        Set<org.javaruntype.type.Type<?>> supertypes = supertypes(p.getType());
+        Set<org.javaruntype.type.Type<?>> supertypes = new LinkedHashSet<>(supertypes(p.getType()));
         org.javaruntype.type.Type<?> choice = choose(supertypes, random);
 
         typeParameterContexts.add(

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/Reflection.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/Reflection.java
@@ -48,7 +48,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,7 +135,7 @@ public final class Reflection {
     }
 
     public static Set<Type<?>> supertypes(Type<?> bottom) {
-        Set<Type<?>> supertypes = new HashSet<>();
+        Set<Type<?>> supertypes = new LinkedHashSet<>();
         supertypes.add(bottom);
         supertypes.addAll(bottom.getAllTypesAssignableFromThis());
         return supertypes;


### PR DESCRIPTION
This PR fixes the following flaky tests related to [SetOfSuperFloatPropertyParameterTest.java](https://github.com/pholser/junit-quickcheck/blob/dd777a4b63050f51b1476b27fdf296fa2487f9aa/generators/src/test/java/com/pholser/junit/quickcheck/generator/java/util/SetOfSuperFloatPropertyParameterTest.java):

1. [verifyInteractionWithRandomness](https://github.com/pholser/junit-quickcheck/blob/dd777a4b63050f51b1476b27fdf296fa2487f9aa/generators/src/test/java/com/pholser/junit/quickcheck/generator/java/util/SetOfSuperFloatPropertyParameterTest.java#L77C27-L77C58)
2. [producesExpectedRandomValues](https://github.com/pholser/junit-quickcheck/blob/dd777a4b63050f51b1476b27fdf296fa2487f9aa/core/src/test/java/com/pholser/junit/quickcheck/internal/generator/CorePropertyParameterTest.java#L156)

These tests initially were non-deterministic and were identified by the NonDex tool.
The non-determinism was caused because [**_HashSet_**](https://github.com/pholser/junit-quickcheck/blob/master/core/src/main/java/com/pholser/junit/quickcheck/internal/Reflection.java#L138) does not obey ordering.  This PR makes use of **_LinkedHashSet_** to ensure ordering is obeyed.

The changes in the PR does not affect any of the other tests, which can be verified by running: `mvn test` and `mvn verify`
The tests are not flaky anymore too which can be verified by running the NonDex tool.

The tests fail with the following error (the error is **non-determinstic** as well, a few times Boolean function is called, a few times Byte function is called etc.):
``` 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.pholser.junit.quickcheck.generator.java.util.SetOfSuperFloatPropertyParameterTest
[MockitoHint] SetOfSuperFloatPropertyParameterTest.verifyInteractionWithRandomness (see javadoc for MockitoHint):
[MockitoHint] 1. Unused... -> at com.pholser.junit.quickcheck.Generating.ints(Generating.java:117)
[MockitoHint]  ...args ok? -> at com.pholser.junit.quickcheck.internal.Items.choose(Items.java:58)
[MockitoHint]  ...args ok? -> at com.pholser.junit.quickcheck.internal.Items.choose(Items.java:58)
[MockitoHint]  ...args ok? -> at com.pholser.junit.quickcheck.internal.Items.choose(Items.java:58)

[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.450 s <<< FAILURE! -- in com.pholser.junit.quickcheck.generator.java.util.SetOfSuperFloatPropertyParameterTest
[ERROR] com.pholser.junit.quickcheck.generator.java.util.SetOfSuperFloatPropertyParameterTest.verifyInteractionWithRandomness -- Time elapsed: 2.436 s <<< FAILURE!
Wanted but not invoked:
randomForParameterGenerator.nextFloat(
    0.0f,
    1.0f
);
-> at com.pholser.junit.quickcheck.Generating.verifyFloats(Generating.java:102)

However, there were exactly 3 interactions with this mock:
randomForParameterGenerator.nextBoolean();
-> at com.pholser.junit.quickcheck.generator.java.lang.BooleanGenerator.generate(BooleanGenerator.java:52)

randomForParameterGenerator.nextBoolean();
-> at com.pholser.junit.quickcheck.generator.java.lang.BooleanGenerator.generate(BooleanGenerator.java:52)

randomForParameterGenerator.nextBoolean();
-> at com.pholser.junit.quickcheck.generator.java.lang.BooleanGenerator.generate(BooleanGenerator.java:52)

[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

Run the above tests with the following command:
1. `mvn -pl generators test  -Dtest=com.pholser.junit.quickcheck.generator.java.util.SetOfSuperFloatPropertyParameterTest#verifyInteractionWithRandomness`
2. `mvn -pl generators test  -Dtest=com.pholser.junit.quickcheck.generator.java.util.SetOfSuperFloatPropertyParameterTest#producesExpectedRandomValues `


**_Explanation:_**

For all supertypes, there are a list of close match classes generated and inserted into a Hashset. The closest match is added first, subsequently the rest are added to the set. For instance, superfloat can generate boolean, number, float as its types, and float is its closest match.
In a HashSet, when the first element is returned it can return either boolean or number or float even if float, the closest match is inserted first. This causes the non-determinism/flakiness (since order of insertion is not obeyed).
To ensure that the closest match inserted into the set is always returned and eliminate non-determinism or flakiness, a `LinkedHashSet` can be utilized. This data structure maintains the order of elements based on their insertion sequence, ensuring that the first element returned is always the closest match (that is inserted first) thereby fixing the non-determinism.

 Run the following tests using NonDex with the following commands:
1. `mvn -pl generators test edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.pholser.junit.quickcheck.generator.java.util.SetOfSuperFloatPropertyParameterTest#producesExpectedRandomValues -DnondexRuns=100`
2.  `mvn -pl generators test edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.pholser.junit.quickcheck.generator.java.util.SetOfSuperFloatPropertyParameterTest#verifyInteractionWithRandomness -DnondexRuns=10`
